### PR TITLE
Bug: forced to select an accommodation when ordering

### DIFF
--- a/frontend/src/components/MenuItemPopup.js
+++ b/frontend/src/components/MenuItemPopup.js
@@ -73,7 +73,7 @@ const MenuItemPopup = ({ values, togglePopup, processForm }) => {
                 {values.get("accommodations").map((accommodation) => {
                     return(
                         <label className="choice-label">
-                            <input type="checkbox" name="accommodations" value={accommodation.Description} id={accommodation.Description} onChange={(e) => handleAccommodation(e, accommodation.Price)} required />
+                            <input type="checkbox" name="accommodations" value={accommodation.Description} id={accommodation.Description} onChange={(e) => handleAccommodation(e, accommodation.Price)} />
                             <span className="label-title">{accommodation.Description + " +($" + parseFloat(accommodation.Price).toFixed(2) + ")"}</span>
                         </label>
                     );


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 904869142
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Remove `required` keyword from accommodations input tag.

### Testing
How did you confirm your changes worked? 
- Was able to successfully submit the popup form without selecting an accommodation.

### Confirmation of Change 
- You can see that the form does not prompt the user to select an accommodation:
- https://gyazo.com/77d0820d939e1386e082f675d0d966c0.gif
