### PR TITLE
Update pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Directories containing Node.js projects to be linted.
-node_dirs=(. client)
+node_dirs=(frontend backend)
 
 # Command to run in each directory specified in node_dirs.
 lint_command=(npm run lint-check)
@@ -82,15 +82,9 @@ lint_check() {
 }
 
 main() {
-	stash_push
-	local stash_push_status="${?}"
+	stash_push && trap stash_pop EXIT
 
 	lint_check
-	local lint_check_status="${?}"
-
-	(( stash_push_status == 0 )) && stash_pop
-
-	exit "${lint_check_status}"
 }
 
 main "${@}"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Directories containing Node.js projects to be linted.
-node_dirs=(frontend backend)
+node_dirs=(. client)
 
 # Command to run in each directory specified in node_dirs.
 lint_command=(npm run lint-check)


### PR DESCRIPTION
This is a minor update to the pre-commit hook (backported from TritonSE/linters), which makes the hook safe to use even if the user cancels the linting process with Ctrl+C.